### PR TITLE
fix capture image screenshot error when background app

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -10,6 +10,7 @@ export const cmdExclusionList = [
   'getscreenshot',
   'status',
   'getreport',
-  'closeapp'
+  'closeapp',
+  'background',  
 ];
 export const testStatusValues = ['PASSED', 'FAILED'];


### PR DESCRIPTION
driver.background() will throw Error: {"code":-32000,"message":"Could not capture image screenshot."}